### PR TITLE
Fixed create_server for Pterodactyl 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ client = PterodactylClient('https://panel.mydomain.com', 'MySuperSecretApiKey')
 # Create a server.  Customize the Nest and Egg IDs to match the IDs in your panel.
 # This server is created with a limit of 8000 MB of memory, no access to swap, unlimited disk space, in location_id 1.
 client.servers.create_server(name='My Paper Server', user_id=1, nest_id=1, 
-                             egg_id=3, memory_limit=8000, swap_limit=0, 
+                             egg_id=3, memory_limit=8000, swap_limit=0, backup_limit=0,
                              disk_limit=0, location_ids=[1])
 <Response [201]>
 ```

--- a/pydactyl/api/servers.py
+++ b/pydactyl/api/servers.py
@@ -162,7 +162,7 @@ class Servers(base.PterodactylAPI):
     def create_server(self, name, user_id, nest_id, egg_id, memory_limit,
                       swap_limit, disk_limit, location_ids=[], port_range=[],
                       environment={}, cpu_limit=0, io_limit=500,
-                      database_limit=0, allocation_limit=0, backup_limit=0,
+                      database_limit=0, allocation_limit=0,
                       docker_image=None, startup_cmd=None, dedicated_ip=False,
                       start_on_completion=True, oom_disabled=True,
                       default_allocation=None, additional_allocations=None):
@@ -260,8 +260,8 @@ class Servers(base.PterodactylAPI):
             },
             'feature_limits': {
                 'databases': database_limit,
-                'allocations': allocation_limit,
-                'backups': backup_limit
+                'allocations': allocation_limit
+                #'backups': backup_limit
             },
             'environment': env_with_defaults,
             'start_on_completion': start_on_completion,

--- a/pydactyl/api/servers.py
+++ b/pydactyl/api/servers.py
@@ -162,7 +162,7 @@ class Servers(base.PterodactylAPI):
     def create_server(self, name, user_id, nest_id, egg_id, memory_limit,
                       swap_limit, disk_limit, location_ids=[], port_range=[],
                       environment={}, cpu_limit=0, io_limit=500,
-                      database_limit=0, allocation_limit=0,
+                      database_limit=0, allocation_limit=0, backup_limit=0,
                       docker_image=None, startup_cmd=None, dedicated_ip=False,
                       start_on_completion=True, oom_disabled=True,
                       default_allocation=None, additional_allocations=None):
@@ -204,6 +204,8 @@ class Servers(base.PterodactylAPI):
                     assigned to this server.
             allocation_limit(int): Maximum number of allocations that can be
                     assigned to this server.
+            backup_limit(int): Maximum number of backups that can be
+                    created for this server.
             docker_image(str): Name or URL of the Docker server to use.
                     e.g. quay.io/pterodactyl/core:java-glibc
             startup_cmd(str): Startup command, if specified replaces the
@@ -259,6 +261,7 @@ class Servers(base.PterodactylAPI):
             'feature_limits': {
                 'databases': database_limit,
                 'allocations': allocation_limit,
+                'backups': backup_limit
             },
             'environment': env_with_defaults,
             'start_on_completion': start_on_completion,

--- a/pydactyl/api/servers.py
+++ b/pydactyl/api/servers.py
@@ -162,7 +162,7 @@ class Servers(base.PterodactylAPI):
     def create_server(self, name, user_id, nest_id, egg_id, memory_limit,
                       swap_limit, disk_limit, location_ids=[], port_range=[],
                       environment={}, cpu_limit=0, io_limit=500,
-                      database_limit=0, allocation_limit=0,
+                      database_limit=0, allocation_limit=0, backup_limit=0,
                       docker_image=None, startup_cmd=None, dedicated_ip=False,
                       start_on_completion=True, oom_disabled=True,
                       default_allocation=None, additional_allocations=None):
@@ -260,8 +260,8 @@ class Servers(base.PterodactylAPI):
             },
             'feature_limits': {
                 'databases': database_limit,
-                'allocations': allocation_limit
-                #'backups': backup_limit
+                'allocations': allocation_limit,
+                'backups': backup_limit
             },
             'environment': env_with_defaults,
             'start_on_completion': start_on_completion,


### PR DESCRIPTION
Fixed by adding backup limit support, which was previously causing an error.
Also updated readme.md to include the change.